### PR TITLE
[ICATHALES-491] Fix failure If camera unavailable

### DIFF
--- a/src/LambdaCamera.cpp
+++ b/src/LambdaCamera.cpp
@@ -33,7 +33,10 @@ Camera::CameraThread::~CameraThread()
 {
     DEB_MEMBER_FUNCT();
     DEB_TRACE() << "The CameraThread thread was terminated.";
-    CmdThread::abort();
+    if (getStatus() != CmdThread::InInit)
+    {
+        CmdThread::abort();  
+    }
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Do not abort CmdThread if the thread is not started